### PR TITLE
Modified script to not need deck specification in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,6 @@ On a traditional Linux OS, run this script with the following command entered in
 
 For example: `./patch-sciadv.sh 1961950 CHNSteamPatch-v1.0.0-Setup CHNSteamPatch-Installer.exe`.
 
-If running the above command on SteamOS 3.x, the default distro of the Steam Deck, instead use:  
-```sh
-./patch-sciadv.sh <AppID> <PatchDirectory> <PatchInstaller.exe> deck
-```
-
-For example: `./patch-sciadv.sh 1961950 CHNSteamPatch-v1.0.0-Setup CHNSteamPatch-Installer.exe deck`.
-
 As part of the execution of this script, the GUI installer should launch. Follow the instructions in the interface to install the patch. If asked for an installation directory by the installer, use: `Z:/home/<Username>/.local/share/Steam/steamapps/common/<Game>`, replacing <Username> with your Linux username and <Game> with the name of the folder containing the game.
 
 For example, on the Steam Deck: `Z:/home/deck/.local/share/Steam/steamapps/common/CHAOS;HEAD NOAH`.

--- a/patch-sciadv.sh
+++ b/patch-sciadv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Deck detection
-if [[ $(lsb_release -d) =~ "SteamOS Holo" ]]; then deck=1; fi
+if [[ $(cat /etc/os-release | grep "VERSION_CODENAME=holo") ]]; then deck=1; fi
 
 # Set up and install Protontricks
 flatpak install com.github.Matoking.protontricks

--- a/patch-sciadv.sh
+++ b/patch-sciadv.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
+# Deck detection
+if [[ $(lsb_release -d) =~ "SteamOS Holo" ]]; then deck=1; fi
+
 # Set up and install Protontricks
 flatpak install com.github.Matoking.protontricks
 flatpak override --user --filesystem="~/Downloads" com.github.Matoking.protontricks
-if [[ "$4" == "deck" ]]; then
+if [[ $deck ]]; then
   flatpak override --user --filesystem=/run/media/mmcblk0p2/
 fi
 
 # Patch the game
 protontricks="flatpak run com.github.Matoking.protontricks"
-if [[ "$4" == "deck" ]]; then
+if [[ $deck ]]; then
   $protontricks -c "cd ~/Downloads/$2 && STEAM_COMPAT_MOUNTS=/run/media/mmcblk0p2 wine $3" $1
 else
   $protontricks -c "cd ~/Downloads/$2 && wine $3" $1


### PR DESCRIPTION
There is no need to query the user as to whether the script is on a deck. 

- Added detection via `lsb_release -d` into the script
- Removed relevant portion from README