### PR TITLE
Add STEAMGRID image handling and QoL improvements

### DIFF
--- a/patch-sciadv.sh
+++ b/patch-sciadv.sh
@@ -1,19 +1,43 @@
 #!/usr/bin/env bash
+# Inputs
+STEAM_GAME_ID=$1
+PATCH_DIR_NAME=$2
+PATCH_EXE_NAME=$3
+
 
 # Deck detection
 if [[ $(cat /etc/os-release | grep "VERSION_CODENAME=holo") ]]; then deck=1; fi
 
-# Set up and install Protontricks
-flatpak install com.github.Matoking.protontricks
-flatpak override --user --filesystem="~/Downloads" com.github.Matoking.protontricks
-if [[ $deck ]]; then
-  flatpak override --user --filesystem=/run/media/mmcblk0p2/
+if [[ ! $(command -v protontricks) ]]; then
+  # Set up and install Protontricks
+  flatpak install com.github.Matoking.protontricks
+  flatpak override --user --filesystem="~/Downloads" com.github.Matoking.protontricks
+  if [[ $deck ]]; then
+    flatpak override --user --filesystem=/run/media/mmcblk0p2/
+  fi
+  protontricks="flatpak run com.github.Matoking.protontricks"
+else
+  protontricks="protontricks"
 fi
 
-# Patch the game
-protontricks="flatpak run com.github.Matoking.protontricks"
-if [[ $deck ]]; then
-  $protontricks -c "cd ~/Downloads/$2 && STEAM_COMPAT_MOUNTS=/run/media/mmcblk0p2 wine $3" $1
-else
-  $protontricks -c "cd ~/Downloads/$2 && wine $3" $1
+
+# Detect patch STEAMGRID folder and copy *.png contents to Steam userdata
+if [[ $(ls -d "$HOME/Downloads/$PATCH_DIR_NAME/STEAMGRID/"*.png) ]]; then
+  if [[ $(ls -d "$HOME/.local/share/Steam/userdata/"*/config/grid) ]]; then
+    echo -n "Copying custom grid images..."
+      for GRID_DIR in $(ls -d "$HOME/.local/share/Steam/userdata/"*/config/grid); do
+        $(cp "$HOME/Downloads/$PATCH_DIR_NAME/STEAMGRID/"*.png "$GRID_DIR/")
+      done
+    echo "Complete."
+  fi
 fi
+
+
+# Patch the game
+if [[ $deck ]]; then
+  $protontricks -c "cd ~/Downloads/$PATCH_DIR_NAME && STEAM_COMPAT_MOUNTS=/run/media/mmcblk0p2 wine $PATCH_EXE_NAME" $STEAM_GAME_ID
+else
+  $protontricks -c "cd ~/Downloads/$PATCH_DIR_NAME && wine $PATCH_EXE_NAME" $STEAM_GAME_ID
+fi
+
+


### PR DESCRIPTION
This pull request addresses #15.

1. Added detection for pre-existing system protontricks.
2. Added logic to copy *.pngs in STEAMGRID dir to Steam userdata.
3. Edited script args for legibility.

The protontricks change came from when I was testing the full patch, I realized the script *requires* the flatpak version of protontricks. I run the system-level install. I did not want to simply have to install the flatpak version just to make this script work, so I added a check to see if the `protontricks` command exists, and if so, just set the script's internal reference to simplify the final execute commands.

Tested on Nobara linux. Untested on Deck (I do not have one). Steamgrid logic should work fine on Deck assuming Steam is installed within the normal path: `/home/<user>/.local/share/Steam/`